### PR TITLE
[fact] Refactor generate_review_allocations hook

### DIFF
--- a/repobee_plug/__init__.py
+++ b/repobee_plug/__init__.py
@@ -7,10 +7,14 @@ from repobee_plug.containers import HookResult
 from repobee_plug.containers import Status
 from repobee_plug.containers import ExtensionParser
 from repobee_plug.containers import ExtensionCommand
+from repobee_plug.containers import ReviewAllocation
 from repobee_plug.corehooks import PeerReviewHook as _peer_hook
 from repobee_plug.corehooks import APIHook as _api_hook
 from repobee_plug.exthooks import CloneHook as _clone_hook
 from repobee_plug.exthooks import ExtensionCommandHook as _ext_command_hook
+
+from repobee_plug.apimeta import Team, TeamPermission, Issue, IssueState, Repo, API
+from repobee_plug.exception import ExtensionCommandError, HookNameError, PlugError
 
 manager = pluggy.PluginManager(__package__)
 manager.add_hookspecs(_clone_hook)
@@ -26,4 +30,15 @@ __all__ = [
     "Status",
     "ExtensionParser",
     "ExtensionCommand",
+    "ReviewAllocation",
+    "Team",
+    "TeamPermission",
+    "Issue",
+    "Repo",
+    "Issue",
+    "IssueState",
+    "API",
+    "ExtensionCommandError",
+    "HookNameError",
+    "PlugError",
 ]

--- a/repobee_plug/__version.py
+++ b/repobee_plug/__version.py
@@ -1,1 +1,1 @@
-__version__ = "0.8.0-alpha"
+__version__ = "0.8.0-alpha.1"

--- a/repobee_plug/containers.py
+++ b/repobee_plug/containers.py
@@ -88,3 +88,8 @@ class Status(enum.Enum):
     SUCCESS = "success"
     WARNING = "warning"
     ERROR = "error"
+
+
+ReviewAllocation = collections.namedtuple(
+    "ReviewAllocation", "review_team reviewed_team"
+)

--- a/repobee_plug/corehooks.py
+++ b/repobee_plug/corehooks.py
@@ -55,11 +55,11 @@ class PeerReviewHook:
         .. note::
 
             Respecting the ``num_reviews`` argument is optional: only do it if
-            it makes sense.
+            it makes sense. It's good practice to issue a warning if
+            num_reviews is ignored, however.
 
         Args:
-            team: A list of student :py:class:`~repobee_plug.apimeta.Team`
-                tuples.
+            team: A list of :py:class:`~repobee_plug.apimeta.Team` tuples.
             num_reviews: Amount of reviews each student should perform (and
                 consequently amount of reviewers per repo)
         Returns:


### PR DESCRIPTION
Fix #13 

Also exposes more parts of repobee-plug to the public API, which was necessary for the corresponding changes in repobee to make sense.

Sets the version number to 0.8.0-alpha.1